### PR TITLE
Fix initial issue creation bug

### DIFF
--- a/fixtures/model-example/expected.json
+++ b/fixtures/model-example/expected.json
@@ -2,7 +2,7 @@
   "model_name": "my cool molecule",
   "model_description": "This is a prediction for a super cool molecule",
   "ersilia_id": "eos11aa",
-  "publication": "The following link is just an example:\n\nwww.example.com",
+  "publication": "The following link is just an example:\r\n\n\r\n\nwww.example.com",
   "code": null,
   "license": null
 }

--- a/fixtures/multiple-paragraphs/expected.json
+++ b/fixtures/multiple-paragraphs/expected.json
@@ -1,4 +1,4 @@
 {
-  "my_textarea_input": "1st paragraph\n\n2nd paragraph",
-  "another_textarea_input": "1st paragraph\r\n2nd paragraph"
+  "my_textarea_input": "1st paragraph\r\n\n\r\n\n2nd paragraph",
+  "another_textarea_input": "1st paragraph\r\n\n2nd paragraph"
 }

--- a/fixtures/readme-example/expected.json
+++ b/fixtures/readme-example/expected.json
@@ -3,5 +3,5 @@
   "what_happened?": "A bug happened!",
   "version": "1.0.0",
   "what_browsers_are_you_seeing_the_problem_on?": "Chrome, Safari",
-  "code_of_conduct": "- [x] Never give up\r\n- [ ] Hot Dog is a Sandwich"
+  "code_of_conduct": "- [x] Never give up\r\n\n- [ ] Hot Dog is a Sandwich"
 }

--- a/parse.js
+++ b/parse.js
@@ -17,12 +17,7 @@ export async function parse(body) {
     // Loop over the list of sections
     for (const section of issue_body_sections_list) {
         // Split out the issue body sections
-        var splitString
-        if (process.env.CI === 'true') {
-            splitString = "\\r\\n\\r\\n"
-        } else {
-            splitString = "\r\n\r\n"
-        }
+        let splitString = "\n"
 
         let issue_body = section.split(splitString)
         core.debug(issue_body)
@@ -33,7 +28,7 @@ export async function parse(body) {
         // Remove the first element of the list, which is the section header
         issue_body.shift()
         // Join the list back together with newlines
-        issue_body = issue_body.join("\n\n")
+        issue_body = issue_body.slice(1).join("\n\n")
 
         // get the value from the body as well
         let value = issue_body.trim()

--- a/test.spec.js
+++ b/test.spec.js
@@ -33,3 +33,24 @@ it("model example raw string", async () => {
 
   expect(jsonDict).toEqual(expectedOutputJson);
 });
+
+it("test issue body from newly created issue", async () =>{
+  const expectedOutput = {
+    "model_name": "grant test submission",
+    "model_description": "this is a test",
+    "ersilia_id": "eos123test",
+    "slug": "grant-test",
+    "tags": "a,b,c",
+    "publication": null,
+    "code": null,
+    "license": "MIT"
+  }
+  const expectedOutputJson = JSON.stringify(expectedOutput, null, 2);
+
+  const body = "### Model Name\n\ngrant test submission\n\n### Model Description\n\nthis is a test\n\n### Ersilia ID\n\neos123test\n\n### Slug\n\ngrant-test\n\n### Tags\n\na,b,c\n\n### Publication\n\n_No response_\n\n### Code\n\n_No response_\n\n### License\n\nMIT"
+
+  const jsonDict = await parse(body)
+
+  expect(jsonDict).toEqual(expectedOutputJson);
+
+});


### PR DESCRIPTION
## Description
Splits the issue body section by the first newline character instead of by `"\\r\\n\\r\\n"` or `"\r\n\r\n"`. 

This change does maintain the `\r` carriage return characters. 

re: https://github.com/ersilia-os/ersilia/issues/473
>
> So really strange thing... When I first opened this issue and did `/approve` it failed to parse the issue body. I then just edited it via the GitHub web UI, saved it, and it worked perfectly.. So we might need to just make an edit and add a new line somewhere and I'm not quite sure why 😓 
>

## Testing
Created a unit test using the body from [this action run](https://github.com/ersilia-os/ersilia/actions/runs/3461170051/jobs/5778438248)
- ran it on main to verify the bug behavior (all hash values were empty)
- ran it on this test branch and verified it split it as expected